### PR TITLE
fix: CodeStyles is mutable in IDEA / Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .gradle
 /local.properties
 /.idea/caches
+/.idea/codeStyles
 /.idea/libraries
 /.idea/modules.xml
 /.idea/workspace.xml


### PR DESCRIPTION
The files in codeStyles are sometimes-mutable just by loading them in Studio on a different machine, which can present some branching problems and merge conflicts. Adding them to .gitignore seems like the safe and sane answer.